### PR TITLE
Removed footer for origins

### DIFF
--- a/apps/discord-cat/src/main.rs
+++ b/apps/discord-cat/src/main.rs
@@ -219,10 +219,6 @@ async fn send_origins_reply(channel_id: ChannelId, origins: Vec<(&str, String)>,
                 for i in origins.iter() {
                     e.field(i.0, &i.1, true);
                 }
-                e.footer(|f| {
-                    f.icon_url("https://cdn.discordapp.com/emojis/280120125284417536.png?v=1");
-                    f.text("If you like a game, you should support it and buy it!")
-                });
                 debug!("Embed: {:?}", e);
                 e
             });


### PR DESCRIPTION
Removes the footer from the origins detection reply message. Originally it was that "If you buy a game, you should support and buy it", but since that doesnt make sense in every case. So I simply removed it.