### PR TITLE
[NOISSUE] Improved custom build detection

### DIFF
--- a/libs/background-cat/src/lib.rs
+++ b/libs/background-cat/src/lib.rs
@@ -239,17 +239,18 @@ pub(crate) const ORIGINS: [Check; 4] = [
 ];
 
 fn custom_build(log: &str) -> Option<(&str, String)> {
-    const MULTIMC_BUILD: &str = "MultiMC version: 0.";
-    const CUSTOM_BUILD: &str = "-custom\n";
-    
-    if log.contains(MULTIMC_BUILD) {
-        if log.contains(CUSTOM_BUILD) {
+    lazy_static! {
+        static ref RE_OFFICIAL: Regex = Regex::new(r"MultiMC version: 0\.[0-7]\.[0-9]+-[0-9]+").unwrap();
+        static ref RE_CUSTOM: Regex = Regex::new(r"MultiMC version: [a-z0-9\.]+-custom").unwrap();
+    }
+    if RE_OFFICIAL.is_match(log) {
+        None
+    } else {
+        if RE_CUSTOM.is_match(log) {
             Some(("‼", RESPONSES.get("custom-build")?.to_string()))
         } else {
             None
         }
-    } else {
-        None
     }
 }
 


### PR DESCRIPTION
Fixes an issue where the bot would detect valid builds as custom, if a mod had the -custom suffix