### PR TITLE
Update dead too_much_ram link

### DIFF
--- a/apps/discord-cat/src/commands/mod.rs
+++ b/apps/discord-cat/src/commands/mod.rs
@@ -81,7 +81,7 @@ static_text_command! {
         "https://github.com/MultiMC/MultiMC5/wiki/Using-the-right-Java";
     too_much_ram "tmram" "vazkiiram",
         "Allocating too much RAM to Minecraft is bad for performance:",
-        "https://vazkii.net/blog_archive/#blog/ram-explanation";
+        "https://vazkii.notion.site/A-semi-technical-explanation-of-why-you-shouldn-t-allocate-too-much-RAM-to-Minecraft-78e7bd41ba6646de8d1c55c033674bce";
     mod_repost "repost" "vazkiirepost" "9mc" "9minecraft",
         "Please make sure you only download mods from reputable sources.",
         "For more info, please read https://vazkii.net/repost/";


### PR DESCRIPTION
Vazkii's blog has moved and the -too_much_ram link now gives a 404, this updates the link to their new blog.