### PR TITLE
Fix detection of new api.paste.ee links

### DIFF
--- a/apps/discord-cat/src/main.rs
+++ b/apps/discord-cat/src/main.rs
@@ -98,7 +98,7 @@ impl EventHandler for Handler {
         }
 
         lazy_static! {
-            static ref PASTEE_REGEX: Regex = Regex::new(r"https:/{2}paste.ee/p/[^\s/]+").unwrap();
+            static ref PASTEE_REGEX: Regex = Regex::new(r"https:/{2}(?:api\.)?paste\.ee/p/[^\s/]+").unwrap();
         }
 
         if let Some(link) = PASTEE_REGEX.find(&msg.content) {


### PR DESCRIPTION
Allows Background Cat to detect logs that with `api.paste.ee` links, which paste.ee now seems to be returning instead of plain `paste.ee` links. This fixes Background Cat not being able to detect logs generated since paste.ee made this change.