### PR TITLE
Java 21 - Updates detection for BGCAT

### DIFF
--- a/libs/background-cat/src/lib.rs
+++ b/libs/background-cat/src/lib.rs
@@ -134,12 +134,10 @@ fn forge_too_new_java(log: &str) -> Option<(&str, String)> {
 }
 
 fn one_seventeen_plus_java_too_old(log: &str) -> Option<(&str, String)> {
-    //const UNSUPPORTED_CLASS_VERSION_ERROR: &str = "java.lang.UnsupportedClassVersionError: net/minecraft/client/main/Main";   <--- Collides with 21 check.
     const FABRIC_JAVA_VERSION_ERROR: &str = "fabric requires {java @ [>=16]}";
     const FABRIC_JAVA_VERSION_ERROR_SEVENTEEN: &str = "fabric requires {java @ [>=17]}";
     const JAVA_17_WARNING: &str = "Minecraft 1.18 Pre Release 2 and above require the use of Java 17";
 
-    //if log.contains(UNSUPPORTED_CLASS_VERSION_ERROR)
     if log.contains(FABRIC_JAVA_VERSION_ERROR)
         || log.contains(FABRIC_JAVA_VERSION_ERROR_SEVENTEEN)
         || log.contains(JAVA_17_WARNING)
@@ -203,15 +201,6 @@ fn java_architecture(log: &str) -> Option<(&str, String)> {
         None
     }
 }
-
-/* fn winrar_temp(log: &str) -> Option<(&str, String)> {
-    if log.contains("Rar$") {
-        Some(("‼", RESPONSES.get("winrar-temp")?.to_string()))
-    } else {
-      None
-    }
-}
-*/
 
 fn detect_temp_directories(log: &str) -> Option<(&str, String)> {
     lazy_static! {

--- a/libs/background-cat/src/lib.rs
+++ b/libs/background-cat/src/lib.rs
@@ -16,7 +16,6 @@ pub(crate) const PARSERS: [Check; 17] = [
     multimc_in_program_files,
     macos_too_new_java,
     multimc_in_onedrive_managed_folder,
-    //major_java_version,
     forge_too_new_java,
     one_seventeen_plus_java_too_old,
     two_one_plus_java_too_old,
@@ -31,7 +30,6 @@ pub(crate) const PARSERS: [Check; 17] = [
     detect_temp_directories,
     using_system_glfw,
     using_system_openal,
-    //old_multimc_version,
 ];
 
 fn multimc_in_program_files(log: &str) -> Option<(&str, String)> {
@@ -102,26 +100,6 @@ fn multimc_in_onedrive_managed_folder(log: &str) -> Option<(&str, String)> {
         None
     }
 }
-/*
-fn major_java_version(log: &str) -> Option<(&str, String)> {
-    lazy_static! {
-        static ref RE: Regex =
-            Regex::new(r"Java is version (1.)??(?P<ver>[6-9]|[1-9][0-9])+(\..+)??,").unwrap();
-    }
-    match RE.captures(log) {
-        Some(capture) if capture.name("ver")?.as_str() == "8" => None,
-        Some(capture) => Some((
-            "❗",
-            format!(
-                "You're using Java {}. Versions other than Java 8 are not designed to be used with Minecraft and may cause issues. \
-                [See here for help installing the correct version.](https://github.com/MultiMC/MultiMC5/wiki/Using-the-right-Java)",
-                capture.name("ver")?.as_str()
-            ),
-        )),
-        _ => None,
-    }
-}
-*/
 
 fn forge_too_new_java(log: &str) -> Option<(&str, String)> {
     const URLCLASSLOADER_CAST: &str = "java.lang.ClassCastException: class jdk.internal.loader.ClassLoaders$AppClassLoader cannot be cast to class java.net.URLClassLoader";
@@ -233,43 +211,6 @@ fn using_system_glfw(log: &str) -> Option<(&str, String)> {
         None
     }
 }
-/* Regex is incorrect/
-fn old_multimc_version(log: &str) -> Option<(&str, String)> {
-    lazy_static! {
-        static ref RE: Regex =
-            Regex::new(r"MultiMC version: (?P<major_ver>0\.[0-9]+\.[0-9]+-(?P<build>[0-9]+))\n")
-                .unwrap();
-    }
-    if let Some(capture) = RE.captures(log) {
-        match capture.name("build")?.as_str().parse::<u32>() {
-            Ok(o) => {
-                if o < 900 {
-                    Some((
-                        "❗",
-                        format!(
-                            "You seem to be using an old build of MultiMC ({}). \
-                            Please update to a more recent version.",
-                            capture.name("major_ver")?.as_str()
-                        ),
-                    ))
-                } else {
-                    None
-                }
-            }
-            Err(_) => Some((
-                "❗",
-                format!(
-                    "You seem to be using an unofficial version of MultiMC ({}). \
-                    Please only use MultiMC downloaded from [multimc.org](https://multimc.org/#Download).",
-                    capture.name("major_ver")?.as_str()
-                ),
-            )),
-        }
-    } else {
-        None
-    }
-}
-*/
 
 pub fn common_origins(input: &str) -> Vec<(&str, String)> {
     ORIGINS.iter().flat_map(|m| m(input)).collect()

--- a/libs/background-cat/src/lib.rs
+++ b/libs/background-cat/src/lib.rs
@@ -28,7 +28,6 @@ pub(crate) const PARSERS: [Check; 17] = [
     shadermod_optifine_conflict,
     fabric_api_missing,
     java_architecture,
-    //winrar_temp,
     detect_temp_directories,
     using_system_glfw,
     using_system_openal,
@@ -134,12 +133,10 @@ fn forge_too_new_java(log: &str) -> Option<(&str, String)> {
 }
 
 fn one_seventeen_plus_java_too_old(log: &str) -> Option<(&str, String)> {
-    //const UNSUPPORTED_CLASS_VERSION_ERROR: &str = "java.lang.UnsupportedClassVersionError: net/minecraft/client/main/Main";   <--- Collides with 21 check.
     const FABRIC_JAVA_VERSION_ERROR: &str = "fabric requires {java @ [>=16]}";
     const FABRIC_JAVA_VERSION_ERROR_SEVENTEEN: &str = "fabric requires {java @ [>=17]}";
     const JAVA_17_WARNING: &str = "Minecraft 1.18 Pre Release 2 and above require the use of Java 17";
 
-    //if log.contains(UNSUPPORTED_CLASS_VERSION_ERROR)
     if log.contains(FABRIC_JAVA_VERSION_ERROR)
         || log.contains(FABRIC_JAVA_VERSION_ERROR_SEVENTEEN)
         || log.contains(JAVA_17_WARNING)
@@ -203,15 +200,6 @@ fn java_architecture(log: &str) -> Option<(&str, String)> {
         None
     }
 }
-
-/* fn winrar_temp(log: &str) -> Option<(&str, String)> {
-    if log.contains("Rar$") {
-        Some(("‼", RESPONSES.get("winrar-temp")?.to_string()))
-    } else {
-      None
-    }
-}
-*/
 
 fn detect_temp_directories(log: &str) -> Option<(&str, String)> {
     lazy_static! {

--- a/libs/background-cat/src/lib.rs
+++ b/libs/background-cat/src/lib.rs
@@ -12,13 +12,14 @@ pub fn common_mistakes(input: &str) -> Vec<(&str, String)> {
 
 pub(crate) type Check = fn(&str) -> Option<(&str, String)>;
 
-pub(crate) const PARSERS: [Check; 17] = [
+pub(crate) const PARSERS: [Check; 18] = [
     multimc_in_program_files,
     macos_too_new_java,
     multimc_in_onedrive_managed_folder,
     //major_java_version,
     forge_too_new_java,
     one_seventeen_plus_java_too_old,
+    two_one_plus_java_too_old,
     m1_failed_to_find_service_port,
     pixel_format_not_accelerated_win10,
     intel_graphics_icd_dll,
@@ -133,17 +134,26 @@ fn forge_too_new_java(log: &str) -> Option<(&str, String)> {
 }
 
 fn one_seventeen_plus_java_too_old(log: &str) -> Option<(&str, String)> {
-    const UNSUPPORTED_CLASS_VERSION_ERROR: &str = "java.lang.UnsupportedClassVersionError: net/minecraft/client/main/Main";
+    //const UNSUPPORTED_CLASS_VERSION_ERROR: &str = "java.lang.UnsupportedClassVersionError: net/minecraft/client/main/Main";   <--- Collides with 21 check.
     const FABRIC_JAVA_VERSION_ERROR: &str = "fabric requires {java @ [>=16]}";
     const FABRIC_JAVA_VERSION_ERROR_SEVENTEEN: &str = "fabric requires {java @ [>=17]}";
     const JAVA_17_WARNING: &str = "Minecraft 1.18 Pre Release 2 and above require the use of Java 17";
 
-    if log.contains(UNSUPPORTED_CLASS_VERSION_ERROR)
-        || log.contains(FABRIC_JAVA_VERSION_ERROR)
+    //if log.contains(UNSUPPORTED_CLASS_VERSION_ERROR)
+    if log.contains(FABRIC_JAVA_VERSION_ERROR)
         || log.contains(FABRIC_JAVA_VERSION_ERROR_SEVENTEEN)
         || log.contains(JAVA_17_WARNING)
     {
         Some(("‼", RESPONSES.get("use-java-17")?.to_string()))
+    } else {
+        None
+    }
+}
+
+fn two_one_plus_java_too_old(log: &str) -> Option<(&str, String)> {
+    const JAVA_CHECK_CLASS_FILE_VERSION: &str = "(class file version 65.0)";
+    if log.contains(JAVA_CHECK_CLASS_FILE_VERSION) {
+        Some(("‼", RESPONSES.get("use-java-21")?.to_string()))
     } else {
         None
     }

--- a/libs/background-cat/src/lib.rs
+++ b/libs/background-cat/src/lib.rs
@@ -12,7 +12,7 @@ pub fn common_mistakes(input: &str) -> Vec<(&str, String)> {
 
 pub(crate) type Check = fn(&str) -> Option<(&str, String)>;
 
-pub(crate) const PARSERS: [Check; 18] = [
+pub(crate) const PARSERS: [Check; 17] = [
     multimc_in_program_files,
     macos_too_new_java,
     multimc_in_onedrive_managed_folder,
@@ -28,7 +28,7 @@ pub(crate) const PARSERS: [Check; 18] = [
     shadermod_optifine_conflict,
     fabric_api_missing,
     java_architecture,
-    winrar_temp,
+    //winrar_temp,
     detect_temp_directories,
     using_system_glfw,
     using_system_openal,
@@ -204,19 +204,23 @@ fn java_architecture(log: &str) -> Option<(&str, String)> {
     }
 }
 
-fn winrar_temp(log: &str) -> Option<(&str, String)> {
+/* fn winrar_temp(log: &str) -> Option<(&str, String)> {
     if log.contains("Rar$") {
         Some(("‼", RESPONSES.get("winrar-temp")?.to_string()))
     } else {
       None
     }
 }
+*/
 
 fn detect_temp_directories(log: &str) -> Option<(&str, String)> {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"Minecraft folder is:\n[A-Z]:/([^/]+/)*Temp").unwrap();
     }
-    if RE.is_match(log) {
+    if log.contains("Rar$") {
+        Some(("‼", RESPONSES.get("winrar-temp")?.to_string()))
+    }
+    else if RE.is_match(log) && !log.contains("forge_installer") {
         Some(("‼", RESPONSES.get("temp-folder")?.to_string()))
     }
     else {

--- a/libs/background-cat/src/responses.rs
+++ b/libs/background-cat/src/responses.rs
@@ -67,6 +67,13 @@ lazy_static! {
             }
         ),
         (
+            "use-java-21",
+            indoc! {
+                "You are playing a version of Minecraft that requires Java 21 or newer, but are using an older Java version.\n\
+                [Please check our wiki for more information.](https://github.com/MultiMC/Launcher/wiki/Using-the-right-Java#minecraft-210-and-newer)"
+            }
+        ),
+        (
             "apple-silicon-incompatible-forge",
             indoc! {
                 "You seem to be using an Apple M1 Mac with an incompatible version of Forge. Add the following to your launch arguments as a workaround: `-Dfml.earlyprogresswindow=false`"

--- a/libs/background-cat/src/responses.rs
+++ b/libs/background-cat/src/responses.rs
@@ -102,7 +102,7 @@ lazy_static! {
         (
             "winrar-temp",
             indoc! {"
-                Tou did not extract MultiMC to a real folder and are running it from WinRar. Windows will remove it.\n\
+                You did not extract MultiMC to a real folder and are running it from WinRar. Windows will remove it.\n\
                 To prevent data loss, you should extract it somewhere, like the C: top directory."
             }
         ),


### PR DESCRIPTION
This changes the detection for Java 17 to prevent it from colliding with the Java 21 detect. This adds the new detection for java 21.

Changes: 
- Java 17 no longer detected with Java 21.
- Now detects Minecraft versions that require Java 21.
- Updated the temporary directory check to prevent it from checking for the temp folder twice for two different instances such as WINRAR and the normal temporary directory. This caused the bot to report two errors for the same directory.
- Removed Forge Installer temporary folder being detected as a regular temp folder.
- Corrected typo in Winrar response.

