### PR TITLE
NOISSUE: add pastee.dev detection for logs

### DIFF
--- a/apps/discord-cat/src/main.rs
+++ b/apps/discord-cat/src/main.rs
@@ -98,7 +98,7 @@ impl EventHandler for Handler {
         }
 
         lazy_static! {
-            static ref PASTEE_REGEX: Regex = Regex::new(r"https:/{2}paste.ee/p/[^\s/]+").unwrap();
+            static ref PASTEE_REGEX: Regex = Regex::new(r"https:/{2}(paste|pastee).(ee|dev)/p/[^\s/]+").unwrap();
         }
 
         if let Some(link) = PASTEE_REGEX.find(&msg.content) {


### PR DESCRIPTION
This should now allow https://pastee.dev/ to be used for pulling logs in background-cat.